### PR TITLE
Add `disable_sending_content` setting

### DIFF
--- a/app/views/settings/_redmine_issue_assign_notice_settings.html.erb
+++ b/app/views/settings/_redmine_issue_assign_notice_settings.html.erb
@@ -19,6 +19,13 @@
     For Slack, specify a member ID. For Rocket.Chat, specify a Username. For Google Chat, specify a user ID.
   </em>
 </p>
+<p>
+  <label for="settings_disable_sending_content">Disable sending description and notes?</label>
+  <%= check_box_tag 'settings[disable_sending_content]', '1', @settings[:disable_sending_content] == '1' %>
+  <em class="info">
+    If you checked, the issue description and notes will not be included in notices
+  </em>
+</p>
 <script>
 //<![CDATA[
   function changeEnableAssignNoticeUrl() {

--- a/lib/redmine_issue_assign_notice/issue_hook_listener.rb
+++ b/lib/redmine_issue_assign_notice/issue_hook_listener.rb
@@ -47,6 +47,8 @@ module RedmineIssueAssignNotice
         notice_url = Setting.plugin_redmine_issue_assign_notice['notice_url']
       end
 
+      note = '' if Setting.plugin_redmine_issue_assign_notice['disable_sending_content'] == '1'
+
       if notice_url.blank?
         return
       end


### PR DESCRIPTION
When enabled, updates of issue description and notes will not be included in notifications. This is useful to prevent sensitive posts to Redmine from being disclosed via chat apps.

<img width="853" alt="图片" src="https://user-images.githubusercontent.com/114863/236989079-ea378dbb-de45-4b76-9eb1-2659b2aadf83.png">
