### PR TITLE
Remove unnecessary "unloadable" method

### DIFF
--- a/lib/redmine_issue_assign_notice/issue_patch.rb
+++ b/lib/redmine_issue_assign_notice/issue_patch.rb
@@ -5,7 +5,6 @@ module RedmineIssueAssignNotice
       base.send(:include, InstanceMethods)
 
       base.class_eval do
-        unloadable # Send unloadable so it will not be unloaded in development
         after_create :create_from_issue_for_assign_notice
         after_save :save_from_issue_for_assign_notice
       end


### PR DESCRIPTION
When running this plugin in trunk's Redmine (Rails 7.1), an exception occurs.
I think this is due to the removal of the unloadable method from Rails. https://github.com/rails/rails/pull/43048/files#diff-ba884c931e36571626f3a271c37fe6fae7bbcbbf0e82d515213f99552704ef53L269-L284

Since unloadable is no longer used in redmine-view-customize, it should be safe to remove it from this plugin as well. https://github.com/onozaty/redmine-view-customize/pull/34

log
```
$ rails s -b 0.0.0.0
=> Booting Puma
=> Rails 7.1.2 application starting in development 
=> Run `bin/rails server --help` for more startup options
Exiting
/usr/local/bundle/gems/activerecord-7.1.2/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined local variable or method `unloadable' for Issue:Class (NameError)
        from /var/lib/redmine/plugins/redmine_issue_assign_notice/lib/redmine_issue_assign_notice/issue_patch.rb:8:in `block in included'
        from /var/lib/redmine/plugins/redmine_issue_assign_notice/lib/redmine_issue_assign_notice/issue_patch.rb:7:in `class_eval'
        from /var/lib/redmine/plugins/redmine_issue_assign_notice/lib/redmine_issue_assign_notice/issue_patch.rb:7:in `included'
        from /var/lib/redmine/plugins/redmine_issue_assign_notice/init.rb:20:in `include'
        from /var/lib/redmine/plugins/redmine_issue_assign_notice/init.rb:20:in `<top (required)>'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:31:in `load'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:31:in `run_initializer'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:108:in `each'
        from /var/lib/redmine/lib/redmine/plugin_loader.rb:108:in `block in load'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:448:in `instance_exec'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:448:in `block in make_lambda'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:202:in `block (2 levels) in halting'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:707:in `block (2 levels) in default_terminator'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:706:in `catch'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:706:in `block in default_terminator'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:203:in `block in halting'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:598:in `block in invoke_before'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:598:in `each'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:598:in `invoke_before'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/callbacks.rb:109:in `run_callbacks'
        from /usr/local/bundle/gems/activesupport-7.1.2/lib/active_support/reloader.rb:96:in `prepare!'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/application/finisher.rb:74:in `block in <module:Finisher>'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:32:in `instance_exec'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:32:in `run'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:61:in `block in run_initializers'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:228:in `block in tsort_each'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `each'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `call'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:347:in `each_strongly_connected_component'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:226:in `tsort_each'
        from /usr/local/lib/ruby/3.2.0/tsort.rb:205:in `tsort_each'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/initializable.rb:60:in `run_initializers'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/application.rb:423:in `initialize!'
        from /var/lib/redmine/config/environment.rb:16:in `<top (required)>'
        from config.ru:3:in `require_relative'
        from config.ru:3:in `block in <main>'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:103:in `eval'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:103:in `new_from_string'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:94:in `load_file'
        from /usr/local/bundle/gems/rack-3.0.8/lib/rack/builder.rb:64:in `parse_file'
        from /usr/local/bundle/gems/rackup-2.1.0/lib/rackup/server.rb:354:in `build_app_and_options_from_config'
        from /usr/local/bundle/gems/rackup-2.1.0/lib/rackup/server.rb:263:in `app'
        from /usr/local/bundle/gems/rackup-2.1.0/lib/rackup/server.rb:424:in `wrapped_app'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:76:in `log_to_stdout'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:36:in `start'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:145:in `block in perform'
        from <internal:kernel>:90:in `tap'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands/server/server_command.rb:136:in `perform'
        from /usr/local/bundle/gems/thor-1.3.0/lib/thor/command.rb:28:in `run'
        from /usr/local/bundle/gems/thor-1.3.0/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command/base.rb:178:in `invoke_command'
        from /usr/local/bundle/gems/thor-1.3.0/lib/thor.rb:527:in `dispatch'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command/base.rb:73:in `perform'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command.rb:71:in `block in invoke'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command.rb:149:in `with_argv'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/command.rb:69:in `invoke'
        from /usr/local/bundle/gems/railties-7.1.2/lib/rails/commands.rb:18:in `<top (required)>'
        from bin/rails:4:in `require'
        from bin/rails:4:in `<main>'
```