### PR TITLE
Add notifications for all users in a group

### DIFF
--- a/lib/redmine_issue_assign_notice/issue_hook_listener.rb
+++ b/lib/redmine_issue_assign_notice/issue_hook_listener.rb
@@ -40,6 +40,13 @@ module RedmineIssueAssignNotice
 
     def notice(issue, old_assgined_to, new_assgined_to, note, author)
 
+      if new_assgined_to.is_a?(Group)
+        new_assgined_to.users.each do |user|
+          notice(issue, old_assgined_to, user, note, author)
+        end
+        return
+      end
+      
       if Setting.plugin_redmine_issue_assign_notice['notice_url_each_project'] == '1'
         notice_url_field = issue.project.custom_field_values.find{ |field| field.custom_field.name == 'Assign Notice URL' }
         notice_url = notice_url_field.value unless notice_url_field.nil?


### PR DESCRIPTION
Redmine has a feature that allows issue to be assigned to a group rather than an user. When this feature is enabled and a issue is assigned to a group, notifications are sent to all members of the group.

Additionally, this has been tested in Teams.