### PR TITLE
Add notifications for all users in a group

### DIFF
--- a/lib/redmine_issue_assign_notice/issue_hook_listener.rb
+++ b/lib/redmine_issue_assign_notice/issue_hook_listener.rb
@@ -38,8 +38,15 @@ module RedmineIssueAssignNotice
 
     private
 
-    def notice(issue, old_assgined_to, new_assgined_to, note, author)
+    def notice(issue, old_assgined_to, new_assgined_to, note, author, group_name = nil)
 
+      if new_assgined_to.is_a?(Group)
+        new_assgined_to.users.each do |user|
+          notice(issue, old_assgined_to, user, note, author, new_assgined_to)
+        end
+        return
+      end
+      
       if Setting.plugin_redmine_issue_assign_notice['notice_url_each_project'] == '1'
         notice_url_field = issue.project.custom_field_values.find{ |field| field.custom_field.name == 'Assign Notice URL' }
         notice_url = notice_url_field.value unless notice_url_field.nil?
@@ -55,7 +62,7 @@ module RedmineIssueAssignNotice
 
       message_creator = MessageCreator.from(notice_url)
 
-      message = message_creator.create(issue, old_assgined_to, new_assgined_to, note, author)
+      message = message_creator.create(issue, old_assgined_to, new_assgined_to, note, author, group_name)
 
       Rails.logger.debug "[RedmineIssueAssignNotice] IssueHookListener#notice message:#{message}"
 

--- a/lib/redmine_issue_assign_notice/message_creator.rb
+++ b/lib/redmine_issue_assign_notice/message_creator.rb
@@ -24,7 +24,7 @@ module RedmineIssueAssignNotice
         @formatter = formatter
       end
   
-      def create(issue, old_assgined_to, new_assgined_to, note, author)
+      def create(issue, old_assgined_to, new_assgined_to, note, author, group_name = nil)
   
         text = ""
   
@@ -33,8 +33,13 @@ module RedmineIssueAssignNotice
           text << @formatter.mention(mention_id)
           text << " "
         end
+
+        if group_name.nil?
+          text << "Assign changed from #{@formatter.user_name old_assgined_to} to #{@formatter.user_name new_assgined_to}"
+        else
+          text << "Assign changed from #{@formatter.user_name old_assgined_to} to #{group_name}"
+        end
   
-        text << "Assign changed from #{@formatter.user_name old_assgined_to} to #{@formatter.user_name new_assgined_to}"
         text << @formatter.change_line
         text << "[#{@formatter.escape issue.project}] "
         text << @formatter.link("#{issue.tracker} ##{issue.id}", MessageHelper.issue_url(issue))
@@ -51,7 +56,7 @@ module RedmineIssueAssignNotice
         @formatter = Formatter::Teams.new
       end
   
-      def create(issue, old_assgined_to, new_assgined_to, note, author)
+      def create(issue, old_assgined_to, new_assgined_to, note, author, group_name = nil)
   
         text = ""
 
@@ -61,7 +66,12 @@ module RedmineIssueAssignNotice
           text << mention_part + " "
         end
 
-        text << "Assign changed from #{@formatter.user_name old_assgined_to} to #{@formatter.user_name new_assgined_to}"
+        if group_name.nil?
+          text << "Assign changed from #{@formatter.user_name old_assgined_to} to #{@formatter.user_name new_assgined_to}"
+        else
+          text << "Assign changed from #{@formatter.user_name old_assgined_to} to #{group_name}"
+        end
+        
         text << @formatter.change_line
         text << "[#{@formatter.escape issue.project}] "
         text << @formatter.link("#{issue.tracker} ##{issue.id}", MessageHelper.issue_url(issue))


### PR DESCRIPTION
Thank you for creating such a fantastic plugin.
I have added the functionality I needed.

Redmine has a feature that allows issue to be assigned to a group rather than an user. When this feature is enabled and a issue is assigned to a group, notifications are sent to all members of the group.
Additionally, this has been tested in Teams.